### PR TITLE
Add default browserslist to silence react-scripts on start

### DIFF
--- a/Reactjs/.browserslistrc
+++ b/Reactjs/.browserslistrc
@@ -1,0 +1,4 @@
+>0.2%
+not dead
+not ie <= 11
+not op_mini all


### PR DESCRIPTION
When running `npm run start`, `react-scripts` suggests adding a default `.broserslistrc` file.