### PR TITLE
Instruct git to treat NPM files with LF line endings

### DIFF
--- a/Reactjs/.gitattributes
+++ b/Reactjs/.gitattributes
@@ -1,0 +1,15 @@
+###############################################################################
+# Set default behavior to automatically normalize line endings.
+###############################################################################
+* text=auto
+
+###############################################################################
+# Behaviour for NPM package files
+#
+# Because NPM writes back a package.json (and the lockfile) you get file
+# changes after each NPM operation on CRLF systems.
+# Set Git to checkout these files with LF line-endings
+###############################################################################
+package.json        text    eol=lf
+package-lock.json   text    eol=lf
+yarn.lock           text    eol=lf


### PR DESCRIPTION
Behaviour for NPM package files

Because NPM writes back a package.json (and the lockfile) you get file changes after each NPM operation on CRLF (i.e. Windows) systems.

Set Git to checkout these files with LF line-endings
